### PR TITLE
Skip provider registration when NVIDIA_NIM_API_KEY is unset (fixes #5)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -636,6 +636,28 @@ async function fetchNimModels(apiKey: string): Promise<string[]> {
 // =============================================================================
 
 export default function (pi: ExtensionAPI) {
+	// Bail out cleanly if the user hasn't set up an API key yet. Without this
+	// guard, pi's flow can still route requests through this provider's
+	// streamSimple (e.g. when probing available providers, or when the
+	// configured default provider can't be resolved for any reason), which
+	// causes a fatal "NVIDIA_NIM_API_KEY environment variable is not set"
+	// error to be emitted on every `pi` invocation — even when the user
+	// never intended to use NVIDIA NIM. Skipping registration leaves the
+	// extension dormant: no NIM models appear in the picker, no provider is
+	// available to route to, and other providers (OpenAI, Anthropic, custom
+	// OpenAI-compatible endpoints in models.json, etc.) work normally.
+	//
+	// Re-enable by exporting the key:
+	//   export NVIDIA_NIM_API_KEY=nvapi-...
+	if (!process.env[NVIDIA_NIM_API_KEY_ENV]) {
+		// One-line, stderr, only on first load. Not fatal.
+		console.error(
+			`pi-nvidia-nim: ${NVIDIA_NIM_API_KEY_ENV} not set — extension dormant. ` +
+			`Set the key (https://build.nvidia.com) and reload pi to enable NVIDIA NIM models.`
+		);
+		return;
+	}
+
 	// Build the curated model list
 	const modelMap = new Map<string, NimModelEntry>();
 
@@ -660,7 +682,7 @@ export default function (pi: ExtensionAPI) {
 	// On session start, discover additional models from the API
 	pi.on("session_start", async (_event: any, ctx: any) => {
 		const apiKey = process.env[NVIDIA_NIM_API_KEY_ENV];
-		if (!apiKey) return; // API key not available, skip model discovery
+		if (!apiKey) return; // belt-and-suspenders: skip if env was unset after load
 
 		// Fetch live model list
 		const liveModelIds = await fetchNimModels(apiKey);


### PR DESCRIPTION
## Summary

Fixes #5 — the extension currently emits a fatal "NVIDIA_NIM_API_KEY environment variable is not set" error on every `pi` invocation when the key is missing, even when the user's configured default provider is something else entirely. With this change the extension stays dormant: no NIM provider is registered, no NIM models appear in the picker, and `pi` falls through to whatever provider the user actually configured.

## Diagnosis

`nimStreamSimple` previously threw a fatal `Error` when the API key was missing. That throw is reached even when the user did not actively select the NVIDIA NIM provider — pi can invoke a registered provider's `streamSimple` for reasons beyond explicit user selection (provider probing, default fallback when the configured default provider can't be resolved for any reason, etc.). The thrown error then surfaces to the user as a confusing top-level message and `pi` exits without ever forwarding their prompt to their actually-configured provider.

## Fix

Guard at the top of the default export. If `process.env.NVIDIA_NIM_API_KEY` is unset:

1. Print a single one-line message to stderr ("`pi-nvidia-nim: NVIDIA_NIM_API_KEY not set — extension dormant. ...`").
2. Return early without calling `pi.registerProvider(...)`.
3. The `session_start` listener is also not attached.

With no `nvidia-nim` provider in the registry, pi cannot route to it. Other providers (built-in OpenAI/Anthropic/etc., custom OpenAI-compatible endpoints in `models.json`, providers from other extensions) work normally. Users who set the key and reload pi see the full extension surface restored.

## Repro before / after

```sh
unset NVIDIA_NIM_API_KEY

# settings.json: { "defaultProvider": "my-custom-openai-endpoint", ... }
pi -p --no-session "Say hi"
```

**Before:**

```
NVIDIA NIM: NVIDIA_NIM_API_KEY environment variable is not set. Get a free API key at https://build.nvidia.com and export it: export NVIDIA_NIM_API_KEY=nvapi-...
```
(no model response, exit 0 — pi never reaches the configured custom provider)

**After:**

```
pi-nvidia-nim: NVIDIA_NIM_API_KEY not set — extension dormant. Set the key (https://build.nvidia.com) and reload pi to enable NVIDIA NIM models.

Hi! How can I help you today?
```
(extension stays out of the way; the user's configured provider serves the request)

## Verification

- With `NVIDIA_NIM_API_KEY` unset: `pi -p` prints the dormant line and forwards to the configured non-NIM default provider successfully.
- With `NVIDIA_NIM_API_KEY=<value>` set: extension registers as before, all NIM models appear in the picker, no behavior change for happy-path users.

Tested locally on pi `0.70.2` with the fork installed via `cp index.ts ~/.pi/agent/git/github.com/xRyul/pi-nvidia-nim/index.ts`.

## Notes

- The error message in `nimStreamSimple` is left in place as a belt-and-suspenders fallback in case someone calls `streamSimple` directly without going through the registered provider path. Should never fire in normal operation now.
- README still documents the API key as required — no changes needed there.