### PR TITLE
fix: pass non-NIM openai-completions calls through unchanged

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -460,6 +460,14 @@ function nimStreamSimple(
 	context: Context,
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
+	// pi-coding-agent registers streamSimple globally per `api` type (not per provider).
+	// This streamer is invoked for ALL openai-completions providers (e.g. openrouter, openai),
+	// not just nvidia-nim. Pass non-NIM calls through unchanged so we don't leak the
+	// NVIDIA_NIM_API_KEY into other providers' Authorization headers.
+	if (model.provider !== PROVIDER_NAME) {
+		return streamSimpleOpenAICompletions(model as Model<"openai-completions">, context, options);
+	}
+
 	const thinkingConfig = THINKING_CONFIGS[model.id];
 	const reasoning = options?.reasoning;
 	const isThinkingEnabled = !!reasoning;


### PR DESCRIPTION
## Problem

`pi-coding-agent` registers `streamSimple` **globally per `api` type, not per provider** (see `pi-coding-agent/dist/core/model-registry.js` `applyProviderConfig`). Because this extension declares `api: "openai-completions"`, `nimStreamSimple` becomes the streamer for **every** `openai-completions` provider (OpenRouter, OpenAI, etc.) — not just `nvidia-nim`.

`nimStreamSimple` unconditionally sets `options.apiKey = process.env.NVIDIA_NIM_API_KEY`, so requests to OpenRouter/OpenAI go out with `Bearer nvapi-...` and fail with `401 Missing Authentication header`.

## Repro

With this extension enabled and a valid `OPENROUTER_API_KEY` configured:

```
$ echo "hi" | pi --print --model openrouter/auto
401 Missing Authentication header
```

`fetch` interception confirms `POST https://openrouter.ai/api/v1/chat/completions | Bearer nvapi-... len=77` (NIM key) instead of OpenRouter key (len=80).

## Fix

Early-return at the top of `nimStreamSimple` so non-NIM providers fall through to `streamSimpleOpenAICompletions` with their own credentials. NIM-specific behavior (thinking kwargs, reasoning_effort mapping, content normalization, NIM apiKey injection) only runs when `model.provider === PROVIDER_NAME`.

## Test plan

- [x] `pi --model openrouter/auto` → returns response (no 401)
- [x] `pi --model nvidia-nim/moonshotai/kimi-k2.5` → returns response (NIM still works)
- [x] Sniff confirms correct bearer per provider