### PR TITLE
[codex] fix: prefix env-var apiKey ref with $ to silence registerProvider deprecation warning

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -834,7 +834,7 @@ async function fetchNimModels(apiKey: string): Promise<NimModelFetchResult> {
 // =============================================================================
 
 export default function (pi: ExtensionAPI) {
-	const providerApiKeyConfig = getNimApiKeyEnv() ?? NVIDIA_NIM_API_KEY_ENV;
+	const providerApiKeyConfig = getNimApiKeyEnv() ?? `$${NVIDIA_NIM_API_KEY_ENV}`;
 
 	// Always register the curated model list. The request path resolves credentials
 	// through pi first (CLI override, auth.json, shell command), then falls back to
@@ -897,7 +897,7 @@ export default function (pi: ExtensionAPI) {
 			const allModels = Array.from(modelMap.values());
 			ctx.modelRegistry.registerProvider(PROVIDER_NAME, {
 				baseUrl: NVIDIA_NIM_BASE_URL,
-				apiKey: getNimApiKeyEnv() ?? NVIDIA_NIM_API_KEY_ENV,
+				apiKey: getNimApiKeyEnv() ?? `$${NVIDIA_NIM_API_KEY_ENV}`,
 				api: "openai-completions",
 				authHeader: true,
 				models: allModels,


### PR DESCRIPTION
Prefix env-var API key reference with `$` to silence registerProvider deprecation warning

`pi.registerProvider()` recently started warning when the `apiKey` field is a
bare env-var name like `"NVIDIA_NIM_API_KEY"`. The new contract requires the
`$` prefix to mark the value as an environment variable reference
(`"$NVIDIA_NIM_API_KEY"`); the unprefixed form is now treated as a legacy
reference and will stop resolving in a future release.

Without the prefix, every `pi` startup prints:

```
Deprecation warning: registerProvider("nvidia-nim") apiKey value "NVIDIA_NIM_API_KEY" is treated as a legacy environment variable reference. This will no longer be detected as an environment variable reference in a future release. Pass "$NVIDIA_NIM_API_KEY" instead.
```

## Fix

Two `registerProvider()` call sites in `index.ts` fall back to the bare
`NVIDIA_NIM_API_KEY_ENV` constant when no key is present in the
environment:

- Line 837 (initial registration)
- Line 900 (re-registration on model refresh)

Both now wrap the fallback in `\`$${...}\`` to mark it as an env-var
reference:

```ts
const providerApiKeyConfig = getNimApiKeyEnv() ?? `$${NVIDIA_NIM_API_KEY_ENV}`;
```

The `NVIDIA_NIM_API_KEY_ENV` constant is intentionally left as a bare name
because it is also interpolated into user-facing error messages that show
the user what to `export` (see lines 591 and 593 of `index.ts`).

## Validation

After applying the fix, `pi` starts cleanly with no deprecation warning
and the NVIDIA NIM models continue to resolve their key from
`NVIDIA_NIM_API_KEY` / `NVIDIA_API_KEY` as before. Verified by patching
the installed build in `~/.pi/agent/npm/node_modules/pi-nvidia-nim/` and
running `pi`.
