### PR TITLE
feat: add minimaxai/minimax-m3

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The extension ships with curated metadata for 42 featured models. At startup, it
 | `moonshotai/kimi-k2.6` | ✅ | | 256K |
 | `moonshotai/kimi-k2-thinking` | ✅ | | 128K |
 | `minimaxai/minimax-m2.1` | | | 1M |
+| `minimaxai/minimax-m3` | | ✅ | 1M |
 | `z-ai/glm5` | ✅ | | 128K |
 | `z-ai/glm4.7` | ✅ | | 128K |
 | `openai/gpt-oss-120b` | | | 128K |

--- a/index.ts
+++ b/index.ts
@@ -197,6 +197,7 @@ const VISION_MODELS = new Set([
 	"nvidia/llama-3.1-nemotron-nano-vl-8b-v1",
 	"nvidia/nemotron-nano-12b-v2-vl",
 	"nvidia/cosmos-reason2-8b",
+	"minimaxai/minimax-m3",
 ]);
 
 // Embedding / non-chat models to skip
@@ -269,6 +270,7 @@ const CONTEXT_WINDOWS: Record<string, number> = {
 	"minimaxai/minimax-m2": 1048576,
 	"minimaxai/minimax-m2.1": 1048576,
 	"minimaxai/minimax-m2.7": 204800,
+	"minimaxai/minimax-m3": 1048576,
 	// Meta Llama
 	"meta/llama-3.1-405b-instruct": 131072,
 	"meta/llama-3.1-70b-instruct": 131072,
@@ -396,6 +398,7 @@ const MAX_TOKENS: Record<string, number> = {
 	"minimaxai/minimax-m2": 8192,
 	"minimaxai/minimax-m2.1": 8192,
 	"minimaxai/minimax-m2.7": 8192,
+	"minimaxai/minimax-m3": 8192,
 	"meta/llama-4-maverick-17b-128e-instruct": 16384,
 	"meta/llama-4-scout-17b-16e-instruct": 16384,
 	"z-ai/glm4.7": 16384,
@@ -423,9 +426,10 @@ const FEATURED_MODELS = [
 	"moonshotai/kimi-k2-thinking",
 	"moonshotai/kimi-k2-instruct",
 	"moonshotai/kimi-k2-instruct-0905",
-	"minimaxai/minimax-m2.1",
 	"minimaxai/minimax-m2",
+	"minimaxai/minimax-m2.1",
 	"minimaxai/minimax-m2.7",
+	"minimaxai/minimax-m3",
 	"z-ai/glm5",
 	"z-ai/glm4.7",
 	"openai/gpt-oss-120b",


### PR DESCRIPTION
Add support for minimaxai/minimax-m3

Changes
- VISION_MODELS — M3 is a native multimodal model with ViT encoder supporting image and video inputs (confirmed by model card)
- CONTEXT_WINDOWS — 1,048,576 tokens (1M), matching published specs
- MAX_TOKENS — 8,192 (consistent with sibling MiniMax models)
- FEATURED_MODELS — Added minimaxai/minimax-m3; internal MiniMax ordering changed from m2.1 → m2 → m2.7 → m3 to m2 → m2.1 → m2.7 → m3 for monotonic version order
- README.md — Added M3 row to the featured models table (Vision ✅, 1M context)

- Model available on NVIDIA NIM API: https://docs.api.nvidia.com/nim/reference/minimaxai-minimax-m3
- Model card: https://build.nvidia.com/minimaxai/minimax-m3/modelcard